### PR TITLE
Update freetype to 2.8.1 and harfbuzz to 1.5.1

### DIFF
--- a/ttfautohint-build.sh
+++ b/ttfautohint-build.sh
@@ -23,16 +23,13 @@ INST="$BUILD/local"
 TTFAUTOHINT_BIN="$INST/bin/ttfautohint"
 
 # The library versions.
-FREETYPE_VERSION="2.8"
-HARFBUZZ_VERSION="1.5.0"
+FREETYPE_VERSION="2.8.1"
+HARFBUZZ_VERSION="1.5.1"
 TTFAUTOHINT_VERSION="1.7"
 
 # Necessary patches (lists of at most 10 URLs each separated by whitespace,
 # to be applied in order).
-FREETYPE_PATCHES="\
-  http://git.savannah.gnu.org/cgit/freetype/freetype2.git/patch/?id=c9a9cf59 \
-  http://git.savannah.gnu.org/cgit/freetype/freetype2.git/patch/?id=c8829e4b \
-"
+FREETYPE_PATCHES=""
 HARFBUZZ_PATCHES=""
 TTFAUTOHINT_PATCHES=""
 


### PR DESCRIPTION
Also, we no longer need to apply extra patches to freetype as those are now included in the 2.8.1 release.