### PR TITLE
Update Harfbuzz dependency, add macOS 10.13 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
         - TARGET="build"
       script:
         - make -j $TARGET
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - TARGET="build"
+      script:
+        - make -j $TARGET
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## About
 
-ttfautohint-build includes a simple, straightforward [ttfautohint](https://www.freetype.org/ttfautohint/) build from scratch approach on Linux and OS X platforms.  [FreeType](https://www.freetype.org/) and [Harfbuzz](https://github.com/behdad/harfbuzz) build dependencies (at appropriate release versions) are included in the installation.
+ttfautohint-build includes a simple, straightforward [ttfautohint](https://www.freetype.org/ttfautohint/) build from scratch approach on Linux and macOS platforms.  [FreeType](https://www.freetype.org/) and [Harfbuzz](https://github.com/behdad/harfbuzz) build dependencies (at appropriate release versions) are included in the installation.
 
-The build script is `ttfautohint-build.sh` (located in the root of the repository).  This script is linted with `shellcheck` & `checkbashisms` and is tested for build execution completion on Linux (currently Ubuntu Trusty) and OS X v10.10, v10.11, and v10.12 using [the Travis CI service](https://travis-ci.org/source-foundry/ttfautohint-build).
+The build script is `ttfautohint-build.sh` (located in the root of the repository).  This script is linted with `shellcheck` & `checkbashisms` and is tested for build execution completion on Linux (currently Ubuntu Trusty) and macOS v10.10-v10.13 using [the Travis CI service](https://travis-ci.org/source-foundry/ttfautohint-build).
 
 Builds employ a simple `make` workflow that does not require super user permissions.
 
@@ -14,9 +14,9 @@ Builds employ a simple `make` workflow that does not require super user permissi
 
 - None
 
-### OS X
+### macOS
 
-- OS X v10.11 and above
+- macOS v10.11 and above
 - XCode v7.3 and above
 
 ## Usage

--- a/ttfautohint-build.sh
+++ b/ttfautohint-build.sh
@@ -42,7 +42,7 @@ TTFAUTOHINT_BIN="$INST/bin/ttfautohint"
 
 # The library versions.
 FREETYPE_VERSION="2.8.1"
-HARFBUZZ_VERSION="1.5.1"
+HARFBUZZ_VERSION="1.7.3"
 TTFAUTOHINT_VERSION="1.7"
 
 # Necessary patches (lists of at most 10 URLs each separated by whitespace,


### PR DESCRIPTION
This PR:

- updates Harfbuzz dependency to 1.7.3
- adds macOS 10.13 testing to the Travis CI builds
- changes "OS X" to "macOS" in the README documentation

OK with this @lemzwerg?