### PR TITLE
update Harfbuzz to v2.2.0, expand macOS image CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,12 @@ matrix:
         - TARGET="build"
       script:
         - make -j $TARGET
+    - os: osx
+      osx_image: xcode10.1
+      env:
+        - TARGET="build"
+      script:
+        - make -j $TARGET
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: default build lint shellcheck checkbashisms
+
 default: build
 
 build: ttfautohint-build.sh

--- a/ttfautohint-build.sh
+++ b/ttfautohint-build.sh
@@ -5,7 +5,7 @@
 # This script builds a stand-alone binary for the command line version of
 # ttfautohint, downloading any necessary libraries.
 #
-# Version 2018-Nov-2.
+# Version 2018-Nov-30.
 
 # The MIT License (MIT)
 
@@ -42,7 +42,7 @@ TTFAUTOHINT_BIN="$INST/bin/ttfautohint"
 
 # The library versions.
 FREETYPE_VERSION="2.9.1"
-HARFBUZZ_VERSION="2.1.0"
+HARFBUZZ_VERSION="2.2.0"
 TTFAUTOHINT_VERSION="1.8.2"
 
 # Necessary patches (lists of at most 10 URLs each separated by whitespace,


### PR DESCRIPTION
- Updates Harfbuzz to new minor release version
- adds Travis CI macOS XCode 10.1 image testing