### PR TITLE
update FreeType and Harfbuzz, update macOS testing environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,19 @@ matrix:
       script:
         - make -j $TARGET
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - TARGET="build"
       script:
         - make -j $TARGET
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.6
+      env:
+        - TARGET="build"
+      script:
+        - make -j $TARGET
+    - os: osx
+      osx_image: xcode12
       env:
         - TARGET="build"
       script:

--- a/ttfautohint-build.sh
+++ b/ttfautohint-build.sh
@@ -41,8 +41,8 @@ INST="$BUILD/local"
 TTFAUTOHINT_BIN="$INST/bin/ttfautohint"
 
 # The library versions.
-FREETYPE_VERSION="2.10.1"
-HARFBUZZ_VERSION="2.6.0"
+FREETYPE_VERSION="2.10.2"
+HARFBUZZ_VERSION="2.7.2"
 TTFAUTOHINT_VERSION="1.8.3"
 
 # Necessary patches (lists of at most 10 URLs each separated by whitespace,


### PR DESCRIPTION
FreeType -> 2.10.2
Harfbuzz -> 2.7.2

Adds XCode 10.3, 11.6, 12 to test runners