### PR TITLE
change the path to the tar package in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ make
 
 ```
 $ curl -L -O https://github.com/source-foundry/ttfautohint-build/archive/v1.8.3.2.tar.gz
-$ tar -xzvf ttfautohint-build-1.8.3.2.tar.gz
+$ tar -xzvf v1.8.3.2.tar.gz
 $ cd ttfautohint-build-1.8.3.2
 $ make
 ```


### PR DESCRIPTION
This corrects the path to the tar package in the curl approach.